### PR TITLE
Mcrypt depreciated in PHP 7.2, switch to OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ https://raw.githubusercontent.com/f0rkz/Bootstrap-Nest-Administration-Tool/maste
 
 Prerequisite PHP Packages
 -------------
-*	php5-json
-*	php5-mcrypt
+*	php7-json
 
 INSTALL INSTRUCTIONS
 =============

--- a/includes/nest.conf.php_EXAMPLE
+++ b/includes/nest.conf.php_EXAMPLE
@@ -17,8 +17,8 @@ $timezone = "America/New_York";
 
 // Key for nest password. Since nest does not use API keys per thermostat (yet),
 // we want to encrypt the database contents for safety.
-// Set something random here. You should change this.
-define("ENCRYPTION_KEY", "4jiadg892kwentj923");
+// Use `openssl rand -hex 16` to generate a new key. You should change this.
+define("ENCRYPTION_KEY", "f36199d5166fa04a7d80bffefe62b70b");
 
 // Default username to display for front page graph
 // If you do not want a username set here, please set it NULL without "quotation marks"

--- a/includes/scripts/collect-nest-data.php
+++ b/includes/scripts/collect-nest-data.php
@@ -28,7 +28,7 @@ while ( $row = $users_statement->fetch())
 	}
 	$nest_username = $row['nest_username'];
 	$nest_password = $row['nest_password'];
-	$nest_password_decrypt = trim(decrypt(utf8_decode($nest_password), ENCRYPTION_KEY));
+	$nest_password_decrypt = decrypt($nest_password, ENCRYPTION_KEY);
 	$timestamp = time();
 
 /*

--- a/web/index.php
+++ b/web/index.php
@@ -171,7 +171,7 @@ if (isset($request['page']) && $request['page'] == 'profile')
 			$nest_password = $input['nest']['password'];
 			$nest_location = $input['nest']['location'];
 
-			$nest_password_encrypt = utf8_encode(encrypt($nest_password, ENCRYPTION_KEY));
+			$nest_password_encrypt = encrypt($nest_password, ENCRYPTION_KEY);
 
 			////////////// identify user's time zone
 			$geocord_json = "http://maps.googleapis.com/maps/api/geocode/json?address=" . urlencode($user_location) . "&sensor=false";


### PR DESCRIPTION
You'll need to generate a new key (documented in nest.conf.php_EXAMPLE), and then re-save your Nest login information.